### PR TITLE
Fix CSS class name generation for team totals

### DIFF
--- a/src/html/template-summary.html
+++ b/src/html/template-summary.html
@@ -163,7 +163,7 @@
                                 </tr>
                                 {{/each}}
                                 {{#with teamStats}}
-                                <tr class="total team{{math @index " + " 1}}">
+                                <tr class="total team{{math @index "+" 1}}">
                                     <td>Total</td>
                                     <td>--</td>
                                     <td>{{kills}}</td>


### PR DESCRIPTION
The JS-CSS-HTML Formatter extension for VS Code inserted extra spaces around the "+" which caused the Handlebars "math" helper to not find a matching operator. I've since turned off the formatter.