### PR TITLE
Copy CSS file statically

### DIFF
--- a/src/fileParser.ts
+++ b/src/fileParser.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from 'fs';
+import { copyFile, readFile, writeFile, mkdir } from 'fs';
 
 import * as Handlebars from 'handlebars';
 import pg = require('pg');
@@ -51,6 +51,7 @@ export default async function(
 
         const templateFile = path.join(templateDir, 'template-summary.html');
         const playerTemplate = path.join(templateDir, 'template-summary-player.html');
+        const cssFile = path.join(templateDir, 'hamp2.css');
 
         const logName = await getLogName(pool, allStats.stats[0]!.parse_name, reparse);
         matchMeta.logName = logName;
@@ -66,6 +67,12 @@ export default async function(
             how_dropped: 0,
             timestamp: "LOLZ"
         }];
+
+        // the CSS file should stay in versioned with the output
+        copyFile(cssFile, `${outputDir}/hamp2.css`, (error) => {
+            if (error) console.error(`failed to copy CSS file: ${error}`);
+            console.log(`copied CSS file`);
+        });
 
         readFile(templateFile, 'utf-8', (error, source) => {
             TemplateUtils.registerHelpers();

--- a/src/html/hamp2.css
+++ b/src/html/hamp2.css
@@ -198,56 +198,57 @@ table tr.total {
     border-bottom: 2px solid #333;
 }
 
+.stats {
+    --padding-between-sections: 15px;
+}
+
 .stats td:first-child, .stats th:first-child,
 .stats td:nth-child(2), .stats th:nth-child(2) {
     text-align: left;
 }
 
 /** tks */
-.stats td:nth-child(4), .stats th:nth-child(4),
-.stats td:nth-child(7), .stats th:nth-child(7),
-.stats td:nth-child(8), .stats th:nth-child(8),
-.stats td:nth-child(16), .stats th:nth-child(16),
-.stats td:nth-child(19), .stats th:nth-child(19),
-.stats td:nth-child(20), .stats th:nth-child(20) {
+.stats td.team-kills, .stats th.team-kills,
+.stats td.suicides, .stats th.suicides,
+.stats td.team-deaths, .stats th.team-deaths {
     color: rgb(255, 125, 138);
     text-shadow: 2px 2px 4px #333;
 }
 
 /** minus sign prepend */
-.stats td:nth-child(4)::before, .stats th:nth-child(4)::before,
-.stats td:nth-child(16)::before, .stats th:nth-child(16)::before  {
+.stats td.team-kills::before, .stats th.team-kills::before {
     content: "\2212";
 }
 
-.stats td:nth-child(5), .stats th:nth-child(5),
-.stats td:nth-child(17), .stats th:nth-child(17) {
+.stats td.conc-kills {
+    font-style: italic;
+}
+
+.stats td.sentry-kills, .stats th.sentry-kills {
     color: rgb(18, 194, 221);
     text-shadow: 2px 2px 4px #333;
 }
 
-.stats td:nth-child(5)::before, .stats th:nth-child(5)::before,
-.stats td:nth-child(7)::before, .stats th:nth-child(7)::before,
-.stats td:nth-child(8)::before, .stats th:nth-child(8)::before,
-.stats td:nth-child(17)::before, .stats th:nth-child(17)::before,
-.stats td:nth-child(19)::before, .stats th:nth-child(19)::before,
-.stats td:nth-child(20)::before, .stats th:nth-child(20)::before {
+.stats td.sentry-kills:not(.no-kills)::before, .stats th.sentry-kills::before,
+.stats td.suicides::before, .stats th.suicides::before,
+.stats td.team-deaths::before, .stats th.team-deaths::before {
     content: "+";
 }
 
-.stats td:nth-child(2), .stats th:nth-child(2),
-.stats td:nth-child(5), .stats th:nth-child(5),
-.stats td:nth-child(8), .stats th:nth-child(8),
-.stats td:nth-child(14), .stats th:nth-child(14),
-.stats td:nth-child(17), .stats th:nth-child(17),
-.stats td:nth-child(20), .stats th:nth-child(20),
+.stats td.roles, .stats th.roles,
+.stats td.sentry-kills, .stats th.sentry-kills,
+.stats td.team-deaths, .stats th.team-deaths,
 .summary td:nth-child(1), .summary th:nth-child(1),
 .summary-offense td:nth-child(5), .summary-offense th:nth-child(5),
 .summary-offense td:nth-child(9), .summary-offense th:nth-child(9),
 .summary-defense td:nth-child(4), .summary-defense th:nth-child(4),
 .summary-defense td:nth-child(8), .summary-defense th:nth-child(8) {
     border-right: 1px solid #333;
-    padding-right: 15px;
+    padding-right: var(--padding-between-sections);
+}
+
+.stats td.objectives, .stats th.objectives {
+    padding-right: var(--padding-between-sections);
 }
 
 .stats td:nth-child(0), .stats th:nth-child(0),
@@ -296,45 +297,69 @@ table tr.total {
     background: rgba(248, 249, 250, 0.25);
 }
 
+.table a {
+    color: #66b0ff;
+}
+
+.table a:hover {
+    color: #3395ff;
+}
+
 /** player stats styles */
 
-.player-name {
+#player-details .player-name {
     font-weight: 700;
 }
 
-.player-stats {
+#player-details .player-stats {
     display: grid;
     grid-template-columns: 3rem 1fr 1fr;
     row-gap: 15px;
     column-gap: 40px;
 }
 
-.player-stats .emoji {
+#player-details .player-stats.player-stats-num1 {
+    grid-template-columns: 3rem 1fr;
+}
+
+#player-details .player-stats .emoji {
     font-size: 2rem;
 }
 
-.player-stats .round-title {
+#player-details .player-stats .round-title {
     font-size: 1.5rem;
     font-weight: 700;
     align-self: end;
 }
 
-.player-stats .classes > div {
+#player-details .player-stats .classes > div {
     padding-right: 10px;
     align-items: center;
     justify-content: flex-end;
 }
 
-.stats-facets {
+#player-details .stats-facets {
     display: grid;
-    grid-template-columns: max-content max-content auto;
+    grid-template-columns: auto auto auto;
     column-gap: 15px;
     row-gap: 5px;
 }
 
-.facet-value {
+#player-details .stats-faceted {
+    padding-top: 10px;
+}
+
+#player-details .facet-value {
     font-weight: 700;
     justify-self: end;
+}
+
+#player-details .facet-summary {
+    grid-column: 1 / span 3;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    border-bottom: 1px solid rgba(200, 200, 200, 0.3);
 }
 
 /** weapon styles **/
@@ -349,7 +374,7 @@ table tr.total {
 .weapon-1 { background-position: -150px -224px; width: 24px; height: 16px; }
 .weapon-2 { background-position: -84px -2px; width: 24px; height: 16px;}
 .weapon-3 { background-position: -84px -74px; width: 24px; height: 16px; }
-.weapon-4 { background-position: -84px -112px; width: 24px; height: 16px; }
+.weapon-4 { background-position: -84px -122px; width: 24px; height: 16px; }
 .weapon-5 { background-position: -112px -64px; width: 48px; }
 .weapon-6 { background-position: -112px -42px; width: 48px; }
 .weapon-7 { background-position: 0px -208px; }
@@ -358,14 +383,14 @@ table tr.total {
 .weapon-10 { background-position: 0px -144px; }
 .weapon-11 { background-position: -48px -224px; width: 48px; }
 .weapon-12 { background-position: -96px -208px; width: 48px; }
-.weapon-13 { background-position: 0 -16px; }
+.weapon-13 { background-position: 0px -16px; width: 48px; }
 .weapon-14 { background-position: -112px -4px; width: 36px; }
 .weapon-15 { background-position: -208px -137px; width: 48px; }
-.weapon-16 { background-position: 0px 0px ;} /* TODO (dispenser) */
+.weapon-16 { background-position: -84px -188px; width: 14px; height: 18px; }
 .weapon-17 { background-position: -208px -137px; width: 48px; } /* same as 15 */
 .weapon-18 { background-position: 0px -112px; }
 .weapon-19 { background-position: 0px -128px; }
-.weapon-20 { background-position: 0px 0px; } /* TODO (detpack) */
+.weapon-20 { background-position: -112px -82px; height: 18px; width: 26px; }
 .weapon-21 { background-position: -112px -22px; height: 20px; }
 .weapon-22 { background-position: -84px -26px; width: 24px; }
 .weapon-23 { background-position: -84px -50px; width: 24px; }
@@ -374,7 +399,9 @@ table tr.total {
 .weapon-26 { background-position: -208px -121px; width: 48px; }
 .weapon-27 { background-position: 0px -80px; }
 .weapon-28 { background-position: 0px -96px; }
-.weapon-29, .weapon-30, .weapon-31, .weapon-32, .weapon-33 { background-position: -192px -240px; width: 36px; }
+.weapon-29 { background-position: -84px -170px; width: 18px; }
+.weapon-30, .weapon-31, .weapon-32, .weapon-33 { background-position: -192px -240px; width: 36px; }
+.weapon-34 { background-position: 0px -176px; }
 
 
 /** navbar styles */

--- a/src/html/template-summary-player.html
+++ b/src/html/template-summary-player.html
@@ -12,7 +12,7 @@
         crossorigin="anonymous">
 
     <!-- hamp stylin' -->
-    <link rel="stylesheet" href="/hamp2.css" />
+    <link rel="stylesheet" href="hamp2.css" />
 </head>
 
 <body>

--- a/src/html/template-summary.html
+++ b/src/html/template-summary.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
 
     <!-- hamp stylin' -->
-    <link rel="stylesheet" href="/hamp2.css" />
+    <link rel="stylesheet" href="hamp2.css" />
 </head>
 
 <body>


### PR DESCRIPTION
The template's HTML is intrinsically tied to the CSS file. Since there can be breaking changes over time and we don't want to break older parsed output, the CSS file should be copied into the output folder and referenced there.