### PR TITLE
Reland: Add flag pace graph and fix misc. issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -21,6 +26,259 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/d3": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.1.0.tgz",
+      "integrity": "sha512-gYWvgeGjEl+zmF8c+U1RNIKqe7sfQwIXeLXO5Os72TjDjCEtgpvGBvZ8dXlAuSS1m6B90Y1Uo6Bm36OGR/OtCA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "@types/d3-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.2.tgz",
+      "integrity": "sha512-5mjGjz6XOXKOCdTajXTZ/pMsg236RdiwKPrRPWAEf/2S/+PzwY+LLYShUpeysWaMvsdS7LArh6GdUefoxpchsQ==",
+      "dev": true
+    },
+    "@types/d3-axis": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.1.tgz",
+      "integrity": "sha512-zji/iIbdd49g9WN0aIsGcwcTBUkgLsCSwB+uH+LPVDAiKWENMtI3cJEWt+7/YYwelMoZmbBfzA3qCdrZ2XFNnw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-brush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.1.tgz",
+      "integrity": "sha512-B532DozsiTuQMHu2YChdZU0qsFJSio3Q6jmBYGYNp3gMDzBmuFFgPt9qKA4VYuLZMp4qc6eX7IUFUEsvHiXZAw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-eQfcxIHrg7V++W8Qxn6QkqBNBokyhdWSAS73AbkbMzvLQmVVBviknoz2SRS/ZJdIOmhcmmdCRE/NFOm28Z1AMw==",
+      "dev": true
+    },
+    "@types/d3-color": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.0.2.tgz",
+      "integrity": "sha512-WVx6zBiz4sWlboCy7TCgjeyHpNjMsoF36yaagny1uXfbadc9f+5BeBf7U+lRmQqY3EHbGQpP8UdW8AC+cywSwQ==",
+      "dev": true
+    },
+    "@types/d3-contour": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.1.tgz",
+      "integrity": "sha512-C3zfBrhHZvrpAAK3YXqLWVAGo87A4SvJ83Q/zVJ8rFWJdKejUnDYaWZPkA8K84kb2vDA/g90LTQAz7etXcgoQQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "@types/d3-delaunay": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.0.tgz",
+      "integrity": "sha512-iGm7ZaGLq11RK3e69VeMM6Oqj2SjKUB9Qhcyd1zIcqn2uE8w9GFB445yCY46NOQO3ByaNyktX1DK+Etz7ZaX+w==",
+      "dev": true
+    },
+    "@types/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-NhxMn3bAkqhjoxabVJWKryhnZXXYYVQxaBnbANu0O94+O/nX9qSjrA1P1jbAQJxJf+VC72TxDX/YJcKue5bRqw==",
+      "dev": true
+    },
+    "@types/d3-drag": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.1.tgz",
+      "integrity": "sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-dsv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.0.tgz",
+      "integrity": "sha512-o0/7RlMl9p5n6FQDptuJVMxDf/7EDEv2SYEO/CwdG2tr1hTfUVi0Iavkk2ax+VpaQ/1jVhpnj5rq1nj8vwhn2A==",
+      "dev": true
+    },
+    "@types/d3-ease": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==",
+      "dev": true
+    },
+    "@types/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-toZJNOwrOIqz7Oh6Q7l2zkaNfXkfR7mFSJvGvlD/Ciq/+SQ39d5gynHJZ/0fjt83ec3WL7+u3ssqIijQtBISsw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "@types/d3-force": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.3.tgz",
+      "integrity": "sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==",
+      "dev": true
+    },
+    "@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+      "dev": true
+    },
+    "@types/d3-geo": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.2.tgz",
+      "integrity": "sha512-DbqK7MLYA8LpyHQfv6Klz0426bQEf7bRTvhMy44sNGVyZoWn//B0c+Qbeg8Osi2Obdc9BLLXYAKpyWege2/7LQ==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
+    },
+    "@types/d3-hierarchy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.0.2.tgz",
+      "integrity": "sha512-+krnrWOZ+aQB6v+E+jEkmkAx9HvsNAD+1LCD0vlBY3t+HwjKnsBFbpVLx6WWzDzCIuiTWdAxXMEnGnVXpB09qQ==",
+      "dev": true
+    },
+    "@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-color": "*"
+      }
+    },
+    "@types/d3-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
+      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==",
+      "dev": true
+    },
+    "@types/d3-polygon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
+      "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw==",
+      "dev": true
+    },
+    "@types/d3-quadtree": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
+      "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw==",
+      "dev": true
+    },
+    "@types/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ==",
+      "dev": true
+    },
+    "@types/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-time": "*"
+      }
+    },
+    "@types/d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==",
+      "dev": true
+    },
+    "@types/d3-selection": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.1.tgz",
+      "integrity": "sha512-aJ1d1SCUtERHH65bB8NNoLpUOI3z8kVcfg2BGm4rMMUwuZF4x6qnIEKjT60Vt0o7gP/a/xkRVs4D9CpDifbyRA==",
+      "dev": true
+    },
+    "@types/d3-shape": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.0.2.tgz",
+      "integrity": "sha512-5+ButCmIfNX8id5seZ7jKj3igdcxx+S9IDBiT35fQGTLZUfkFgTv+oBH34xgeoWDKpWcMITSzBILWQtBoN5Piw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-path": "*"
+      }
+    },
+    "@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+      "dev": true
+    },
+    "@types/d3-time-format": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
+      "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw==",
+      "dev": true
+    },
+    "@types/d3-timer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==",
+      "dev": true
+    },
+    "@types/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-Sv4qEI9uq3bnZwlOANvYK853zvpdKEm1yz9rcc8ZTsxvRklcs9Fx4YFuGA3gXoQN/c/1T6QkVNjhaRO/cWj94g==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-zoom": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.1.tgz",
+      "integrity": "sha512-7s5L9TjfqIYQmQQEUcpMAcBOahem7TRoSO/+Gkz02GbMVuULiZzjF2BOdw291dbO2aNon4m2OdFsRGaCq2caLQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
       }
     },
     "@types/events": {
@@ -51,6 +309,22 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
+      "dev": true
+    },
+    "@types/jsdom": {
+      "version": "16.2.13",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.13.tgz",
+      "integrity": "sha512-8JQCjdeAidptSsOcRWk2iTm9wCcwn9l+kRG6k5bzUacrnm1ezV4forq0kWjUih/tumAeoG+OspOvQEbbRucBTw==",
+      "requires": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "@types/mime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
@@ -69,8 +343,12 @@
     "@types/node": {
       "version": "10.17.51",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
-      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg==",
-      "dev": true
+      "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+    },
+    "@types/parse5": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.2.tgz",
+      "integrity": "sha512-+hQX+WyJAOne7Fh3zF5CxPemILIbuhNcqHHodzK9caYOLnC8pD5efmPleRnw0z++LfKUC/sVNMwk0Gap+B0baA=="
     },
     "@types/pg": {
       "version": "7.14.11",
@@ -99,6 +377,16 @@
         "@types/mime": "*"
       }
     },
+    "@types/tough-cookie": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.1.tgz",
+      "integrity": "sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg=="
+    },
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -106,6 +394,55 @@
       "requires": {
         "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
+      }
+    },
+    "acorn": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        }
+      }
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "append-field": {
@@ -117,6 +454,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "body-parser": {
       "version": "1.18.3",
@@ -135,10 +477,15 @@
         "type-is": "~1.6.16"
       }
     },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "buffer-writer": {
       "version": "2.0.0",
@@ -159,11 +506,13 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -226,9 +575,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cors": {
       "version": "2.8.5",
@@ -239,6 +588,314 @@
         "vary": "^1"
       }
     },
+    "cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+        }
+      }
+    },
+    "d3": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.1.1.tgz",
+      "integrity": "sha512-8zkLMwSvUAnfN9pcJDfkuxU0Nvg4RLUD0A4BZN1KxJPtlnCGzMx3xM5cRl4m8fym/Vy8rlq52tl90UF3m91OnA==",
+      "requires": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "3",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      }
+    },
+    "d3-array": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.1.1.tgz",
+      "integrity": "sha512-33qQ+ZoZlli19IFiQx4QEpf2CBEayMRzhlisJHSCsSUbDXv6ZishqS1x7uFVClKG4Wr7rZVHvaAttoLow6GqdQ==",
+      "requires": {
+        "internmap": "1 - 2"
+      }
+    },
+    "d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
+    },
+    "d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      }
+    },
+    "d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "requires": {
+        "d3-path": "1 - 3"
+      }
+    },
+    "d3-color": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
+      "integrity": "sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw=="
+    },
+    "d3-contour": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-3.0.1.tgz",
+      "integrity": "sha512-0Oc4D0KyhwhM7ZL0RMnfGycLN7hxHB8CMmwZ3+H26PWAG0ozNuYG5hXSDNgmP1SgJkQMrlG6cP20HoaSbvcJTQ==",
+      "requires": {
+        "d3-array": "2 - 3"
+      }
+    },
+    "d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "requires": {
+        "delaunator": "5"
+      }
+    },
+    "d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+    },
+    "d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      }
+    },
+    "d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "requires": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+    },
+    "d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "requires": {
+        "d3-dsv": "1 - 3"
+      }
+    },
+    "d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      }
+    },
+    "d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-hdL7+HBIohpgfolhBxr1KX47VMD6+vVD/oEFrxk5yhmzV2prk99EkFKYpXuhVkFpTgHdJ6/4bYcjdLPPXV4tIA=="
+    },
+    "d3-geo": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
+      "integrity": "sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==",
+      "requires": {
+        "d3-array": "2.5.0 - 3"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.0.1.tgz",
+      "integrity": "sha512-RlLTaofEoOrMK1JoXYIGhKTkJFI/6rFrYPgxy6QlZo2BcVc4HGTqEU0rPpzuMq5T/5XcMtAzv1XiLA3zRTfygw=="
+    },
+    "d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "requires": {
+        "d3-color": "1 - 3"
+      }
+    },
+    "d3-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
+      "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w=="
+    },
+    "d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
+    },
+    "d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+    },
+    "d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
+    },
+    "d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "requires": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      }
+    },
+    "d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+      "requires": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      }
+    },
+    "d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+    },
+    "d3-shape": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.0.1.tgz",
+      "integrity": "sha512-HNZNEQoDhuCrDWEc/BMbF/hKtzMZVoe64TvisFLDp2Iyj0UShB/E6/lBsLlJTfBMbYgftHj90cXJ0SEitlE6Xw==",
+      "requires": {
+        "d3-path": "1 - 3"
+      }
+    },
+    "d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
+      "requires": {
+        "d3-array": "2 - 3"
+      }
+    },
+    "d3-time-format": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.0.0.tgz",
+      "integrity": "sha512-nzaCwlj+ZVBIlFuVOT1RmU+6xb/7D5IcnhHzHQcBgS/aTa5K9fWZNN5LCXA27LgF5WxoSNJqKBbLcGMtM6Ca6A==",
+      "requires": {
+        "d3-time": "1 - 3"
+      }
+    },
+    "d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "requires": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      }
+    },
+    "d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      }
+    },
+    "data-urls": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.1.tgz",
+      "integrity": "sha512-Ds554NeT5Gennfoo9KN50Vh6tpgtvYEwraYjejXnyTpu1C7oXKxdFk75REooENHE8ndTVOJuv+BEs4/J/xcozw==",
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^10.0.0"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -246,6 +903,29 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "delaunator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "requires": {
+        "robust-predicates": "^3.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -266,6 +946,14 @@
         "streamsearch": "0.1.2"
       }
     },
+    "domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "requires": {
+        "webidl-conversions": "^7.0.0"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -280,6 +968,33 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -323,6 +1038,11 @@
         "vary": "~1.1.2"
       }
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -337,6 +1057,16 @@
         "unpipe": "~1.0.0"
       }
     },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -348,15 +1078,23 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "requires": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
+      }
+    },
+    "html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "requires": {
+        "whatwg-encoding": "^2.0.0"
       }
     },
     "http-errors": {
@@ -368,6 +1106,55 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
         "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "requires": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "iconv-lite": {
@@ -383,15 +1170,68 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
+    },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "jsdom": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-18.0.1.tgz",
+      "integrity": "sha512-mgVzrYP4IJiJKVqXkAdBn+jg+nQgPusBxTJulz3m1Y/1RIrkk8aDoNaQE5BNbHwe72WwiwE7k3Av2THXDpvzPQ==",
+      "requires": {
+        "abab": "^2.0.5",
+        "acorn": "^8.5.0",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.1",
+        "decimal.js": "^10.3.1",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^3.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^10.0.0",
+        "ws": "^8.2.3",
+        "xml-name-validator": "^4.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -437,13 +1277,6 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        }
       }
     },
     "ms": {
@@ -452,14 +1285,14 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multer": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
-      "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.3.tgz",
+      "integrity": "sha512-np0YLKncuZoTzufbkM6wEKp68EhWJXcU6fq6QqrSwkckd2LlMgd1UqhUJLj6NS/5sZ8dE8LYDWslsltJznnXlg==",
       "requires": {
         "append-field": "^1.0.0",
         "busboy": "^0.2.11",
         "concat-stream": "^1.5.2",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.4",
         "object-assign": "^4.1.1",
         "on-finished": "^2.3.0",
         "type-is": "^1.6.4",
@@ -472,9 +1305,14 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -489,10 +1327,28 @@
         "ee-first": "1.1.1"
       }
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "packet-reader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
       "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
     },
     "parseurl": {
       "version": "1.3.2",
@@ -581,6 +1437,11 @@
         "xtend": "^4.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -594,6 +1455,16 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -627,6 +1498,16 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "robust-predicates": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -636,6 +1517,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "send": {
       "version": "0.16.2",
@@ -726,6 +1615,37 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      }
+    },
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
@@ -741,13 +1661,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz",
-      "integrity": "sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==",
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3"
-      }
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.3.tgz",
+      "integrity": "sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==",
+      "optional": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -769,10 +1691,83 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
+      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
+      "requires": {
+        "xml-name-validator": "^4.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "requires": {
+        "iconv-lite": "0.6.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="
+    },
+    "whatwg-url": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
+      "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+    },
+    "xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "type": "git",
     "url": "git+ssh://git@github.com/bananahampster/hampalyzer.git"
   },
+  "type": "module",
   "keywords": [
     "tfc",
     "hampalyzer",
@@ -23,13 +24,17 @@
   "homepage": "https://github.com/bananahampster/hampalyzer#readme",
   "dependencies": {
     "cors": "^2.8.5",
+    "d3": "^7.1.1",
     "express": "^4.16.4",
-    "handlebars": "^4.7.6",
-    "multer": "^1.4.2",
+    "handlebars": "^4.7.7",
+    "jsdom": "^18.0.1",
+    "multer": "^1.4.3",
     "pg": "^8.5.1"
   },
   "devDependencies": {
+    "@types/d3": "^7.1.0",
     "@types/express": "^4.16.0",
+    "@types/jsdom": "^16.2.13",
     "@types/multer": "^1.4.3",
     "@types/node": "^10.17.51",
     "@types/pg": "^7.14.11"

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,12 +1,12 @@
-import * as express from 'express';
-import cors = require('cors');
-import multer = require('multer');
+import express from 'express';
+import * as cors from 'cors';
+import multer from 'multer';
 
-import fileParser from './fileParser';
-import { Parser } from './parser';
-import path = require('path');
+import fileParser from './fileParser.js';
+import { Parser } from './parser.js';
+import * as path from 'path';
 
-import pg = require('pg');
+import * as pg from 'pg';
 
 // see https://github.com/expressjs/multer
 // and https://medium.com/@petehouston/upload-files-with-curl-93064dcccc76

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,12 +1,12 @@
 import express from 'express';
-import * as cors from 'cors';
+import cors from 'cors';
 import multer from 'multer';
 
 import fileParser from './fileParser.js';
 import { Parser } from './parser.js';
-import * as path from 'path';
+import path from 'path';
 
-import * as pg from 'pg';
+import pg from 'pg';
 
 // see https://github.com/expressjs/multer
 // and https://medium.com/@petehouston/upload-files-with-curl-93064dcccc76

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,15 +13,23 @@ export interface OutputStats {
     game_time: string;
     score: TeamScore;
     teams: TeamsOutputStatsDetailed;
-    flagStats?: FlagStats;
+    scoring_activity?: ScoringActivity;
 }
 
 // expected to be ordered by timestamp ascending
-export type FlagStats = FlagMovement[];
+export type TeamFlagMovements = {
+    [team in TeamColor]?: FlagMovement[];
+ };
+
+export interface ScoringActivity {
+    flag_movements: TeamFlagMovements;
+    game_time_as_seconds: number;
+}
 
 export interface FlagMovement {
     player: string; // steamID
-    timestamp: string; // ?
+    game_time_as_seconds: number,
+    current_score: number,
     how_dropped: FlagDrop;
 }
 
@@ -288,5 +296,8 @@ export namespace TeamColor {
                 console.warn("unknown team received by `parseTeamColor`; assigning to spectator")
                 return TeamColor.Spectator
         }
+    }
+    export function toString(teamColor: TeamColor): string {
+        return (TeamColor as any)[teamColor];
     }
 }

--- a/src/flagPace.ts
+++ b/src/flagPace.ts
@@ -1,0 +1,163 @@
+import { color } from 'd3-color';
+import * as jsdom from 'jsdom';
+import { FlagMovement, ScoringActivity, TeamColor } from './constants.js';
+
+interface ScoreUpdate {
+    team: string,
+    gameTimeAsSeconds: number,
+    currentScore: number,
+}
+export default class FlagPaceChart {
+    data: ScoreUpdate[];
+
+    constructor(roundsScoringActivity: ScoringActivity[])
+    {
+        this.data = FlagPaceChart.flagCapsToScoreUpdates(roundsScoringActivity);
+    }
+    
+    private static flagCapsToScoreUpdates(roundsScoringActivity: ScoringActivity[]): ScoreUpdate[] {
+        let scoreUpdates: ScoreUpdate[] = [];
+
+        roundsScoringActivity.forEach((scoringActivity, roundIndex) => {
+            Object.keys(scoringActivity.flag_movements).forEach((team: string, flagMovementIndex) => {
+                const teamFlagMovements: FlagMovement[] = scoringActivity.flag_movements[team];
+                if (teamFlagMovements) {
+                    const teamColor: TeamColor = parseInt(team);
+                    const currentTeamLabel = `Round ${roundIndex + 1}: ${TeamColor.toString(teamColor)} team`;
+                    if (teamFlagMovements.length > 0) {
+                        // Insert a starting entry for time=0s for all teams with at least one cap.
+                        scoreUpdates.push({
+                            gameTimeAsSeconds: 0,
+                            currentScore: 0,
+                            team: currentTeamLabel
+                        });
+                    }
+                    teamFlagMovements.forEach(flagMovement => {
+                        scoreUpdates.push({
+                            gameTimeAsSeconds: flagMovement.game_time_as_seconds,
+                            currentScore: flagMovement.current_score,
+                            team: currentTeamLabel
+                        });
+                    });
+                    if (teamFlagMovements.length > 0) {
+                        // Insert a terminal entry for time=game_time_as_seconds.
+                        scoreUpdates.push({
+                            gameTimeAsSeconds: scoringActivity.game_time_as_seconds,
+                            currentScore: teamFlagMovements[teamFlagMovements.length - 1].current_score,
+                            team: currentTeamLabel
+                        });
+                    }
+                }
+            });
+        });
+        return scoreUpdates;
+    }
+    
+    public async getSvgMarkup() {
+        // Copyright 2021 Observable, Inc.
+        // Released under the ISC license.
+        // https://observablehq.com/@d3/multi-line-chart
+        // https://observablehq.com/@d3/inline-labels
+
+        const document = new jsdom.JSDOM().window.document;
+
+        const d3 = await import("d3");
+
+        const svgDimensions = { width: 900, height: 600 };
+        const margin = { left: 25, right: 25, top: 30, bottom: 30 };
+
+        const yLabel = "Score";
+        const colors = ["var(--team-a-color)", "var(--team-b-color)", "var(--team-b-color)", "var(--team-a-color)"];
+        const stroke = "currentColor";
+        const strokeLinecap = "round";
+        const strokeLinejoin = "round";
+        const strokeWidth = 5;
+        const strokeOpacity = 1;
+        const curve = d3.curveStep;
+        const mixBlendMode = "lighten";
+
+        const chartDimensions = {
+            width: svgDimensions.width - margin.left - margin.right,
+            height: svgDimensions.height - margin.bottom - margin.top
+        };
+
+        let x = (scoreUpdate: ScoreUpdate) => scoreUpdate.gameTimeAsSeconds;
+        let y = (scoreUpdate: ScoreUpdate) => scoreUpdate.currentScore;
+        let z = (scoreUpdate: ScoreUpdate) => scoreUpdate.team;
+
+        const X = d3.map(this.data, x);
+        const Y = d3.map(this.data, y);
+        const Z = d3.map(this.data, z);
+        const I = d3.range(this.data.length);
+        const defined = (d, i: number) => !isNaN(X[i]) && !isNaN(Y[i]);
+        const D = d3.map(this.data, defined);
+
+        const xDomain: any|any = d3.extent(X);
+        const xRange = [margin.left, chartDimensions.width - margin.right];
+        const yDomain: any|any = [0, d3.max(Y)];
+        const yRange = [chartDimensions.height - margin.bottom, margin.top];
+        const zDomain = new d3.InternSet(Z);
+
+        const xScale = d3.scaleLinear(xDomain, xRange);
+        const yScale = d3.scaleLinear(yDomain, yRange);
+        const color = d3.scaleOrdinal(zDomain, colors);
+        const xAxis = d3.axisBottom(xScale).ticks(Math.round(this.data[this.data.length - 1].gameTimeAsSeconds / 20))
+            .tickFormat((domainValue, index) => {
+                if (domainValue.valueOf() % 60 == 0) {
+                    return `${domainValue.valueOf() / 60}m`;
+                }
+                return "";
+             });
+        const yAxis = d3.axisLeft(yScale).ticks(chartDimensions.height / 60);
+        
+        const line = d3.line<any>()
+            .defined((i) => D[i])
+            .curve(curve)
+            .x((i) => xScale(X[i]))
+            .y(i => yScale(Y[i]));
+
+        const body = d3.select(document).select("body");
+        const svg = body.append("svg")
+            .attr("width", chartDimensions.width)
+            .attr("height", chartDimensions.height)
+            .attr("viewBox", `"0", "0", ${chartDimensions.width}, ${chartDimensions.height}`)
+            .attr("style", "max-width: 100%; height: auto; height: intrinsic;");
+
+        svg.append("g")
+            .attr("transform", `translate(0,${chartDimensions.height - margin.bottom})`)
+            .call(xAxis);
+
+        svg.append("g")
+            .attr("transform", `translate(${margin.left},0)`)
+            .call(yAxis)
+            .call(g => g.select(".domain").remove())
+            .call(g => g.selectAll(".tick line").clone()
+                .attr("x2", chartDimensions.width - margin.left - margin.right)
+                .attr("stroke-opacity", 0.1))
+            .call(g => g.append("text")
+                .attr("x", -margin.left)
+                .attr("y", 10)
+                .attr("fill", "currentColor")
+                .attr("text-anchor", "start")
+                .text(yLabel));
+
+
+        const serie = svg.append("g")
+            .selectAll("g")
+            .data(d3.group(I, i => Z[i]))
+            .join("g");
+
+        const path = serie.append("path")
+            .attr("fill", "none")
+            .attr("stroke", ([key]) => color(key))
+            .attr("stroke-width", strokeWidth)
+            .attr("stroke-linecap", strokeLinecap)
+            .attr("stroke-linejoin", strokeLinejoin)
+            .attr("stroke-opacity", strokeOpacity)
+            .style("mix-blend-mode", mixBlendMode)
+            .attr("d", ([, I]) => line(I));
+
+        return document.body.children[0].outerHTML;
+    }
+
+}

--- a/src/html/hamp2.css
+++ b/src/html/hamp2.css
@@ -1,5 +1,7 @@
 body {
     font-size: .875rem;
+    --team-a-color: rgba(175, 141, 195, 0.65);
+    --team-b-color: rgba(127, 191, 123, 0.65);
 }
 
 .sidebar {
@@ -58,11 +60,11 @@ body {
 }
 
 .sidebar .icon.icon-team-a {
-    background-color: rgba(175, 141, 195, 0.65);
+    background-color: var(--team-a-color);
 }
 
 .sidebar .icon.icon-team-b {
-    background-color: rgba(127, 191, 123, 0.65);
+    background-color: var(--team-b-color);
 }
 
 /** main styles */
@@ -88,11 +90,11 @@ body {
 }
 
 .team-comp > :nth-child(1) {
-    background-color: rgba(175, 141, 195, 0.65);
+    background-color: var(--team-a-color);
 }
 
 .team-comp > :nth-child(2) {
-    background-color: rgba(127, 191, 123, 0.65);
+    background-color: var(--team-b-color);
 }
 
 .stats-round {
@@ -154,7 +156,7 @@ table tr.total {
 }
 
 .summary > :not(thead) tr:nth-child(1) {
-    background-color: rgba(175, 141, 195, 0.65);
+    background-color: var(--team-a-color);
 }
 
 .summary tr.comp td.up {
@@ -162,7 +164,7 @@ table tr.total {
 }
 
 .summary tr:nth-child(3) {
-    background-color: rgba(127, 191, 123, 0.65);
+    background-color: var(--team-b-color);
 }
 
 .summary tr.comp td.down {
@@ -198,7 +200,7 @@ table tr.total {
     border-bottom: 2px solid #333;
 }
 
-.stats {
+.stats, .summary-offense, .summary-defense {
     --padding-between-sections: 15px;
 }
 
@@ -236,28 +238,21 @@ table tr.total {
 }
 
 .stats td.roles, .stats th.roles,
-.stats td.sentry-kills, .stats th.sentry-kills,
-.stats td.team-deaths, .stats th.team-deaths,
-.summary td:nth-child(1), .summary th:nth-child(1),
-.summary-offense td:nth-child(5), .summary-offense th:nth-child(5),
-.summary-offense td:nth-child(9), .summary-offense th:nth-child(9),
-.summary-defense td:nth-child(4), .summary-defense th:nth-child(4),
-.summary-defense td:nth-child(8), .summary-defense th:nth-child(8) {
+td.sentry-kills, th.sentry-kills,
+td.team-deaths, th.team-deaths,
+.summary td.team, .summary th.team,
+.summary-defense td.conc-kills, .summary-defense th.conc-kills {
     border-right: 1px solid #333;
     padding-right: var(--padding-between-sections);
 }
 
-.stats td.objectives, .stats th.objectives {
+.stats td.objectives, .stats th.objectives,
+.summary-offense td.flag-time, .summary-offense th.flag-time,
+.summary-defense td.airshots, .summary-defense th.airshots {
     padding-right: var(--padding-between-sections);
 }
 
-.stats td:nth-child(0), .stats th:nth-child(0),
-.stats td:nth-child(6), .stats th:nth-child(6),
-.stats td:nth-child(9), .stats th:nth-child(9),
-.stats td:nth-child(13), .stats th:nth-child(13),
-.stats td:nth-child(18), .stats th:nth-child(18),
-.stats td:nth-child(21), .stats th:nth-child(21)
-.summary td:nth-child(2), .summary th:nth-child(2),
+
 .summary-offense td:nth-child(6), .summary-offense th:nth-child(6),
 .summary-offense td:nth-child(10), .summary-offense th:nth-child(10),
 .summary-defense td:nth-child(5), .summary-defense th:nth-child(5),

--- a/src/html/template-flag-pace.html
+++ b/src/html/template-flag-pace.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+
+    <title>Hampalyzer TFC Stats: flag pace on {{map}} at {{server}} ({{date}}, {{time}})</title>
+
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
+        crossorigin="anonymous">
+
+    <!-- hamp stylin' -->
+    <link rel="stylesheet" href="hamp2.css" />
+</head>
+
+<body>
+
+    <nav class="navbar navbar-dark fixed-top bg-dark flex-md-nowrap p-0 shadow">
+        <a class="navbar-brand col-sm-3 mr-0" href="/">Hampalyzer &mdash; TFC Statistics</a>
+        <input class="form-control form-control-dark w-100" type="text" placeholder="Search" aria-label="Search" />
+        <ul class="navbar-nav px-3">
+            <li class="nav-item text-nowrap">
+                <a class="nav-link" href="/logs.html">Other Logs</a>
+            </li>
+        </ul>
+    </nav>
+
+    <div class="container-fluid">
+        <div class="row">
+            <nav class="col-md-2 d-none d-md-block bg-dark sidebar">
+                <div class="sidebar-sticky">
+                    <ul class="nav flex-column">
+
+                        <h6 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1">
+                            <span>Overall statistics</span>
+                        </h6>
+                        <li class="nav-item">
+                            <a class="nav-link" href="index.html">
+                                Stats by round
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="index.html#comp">
+                                O/D comparison
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="index.html">
+                                Flag pace
+                            </a>
+                        </li>
+                    </ul>
+
+                    <h6 class="sidebar-heading px-3 mt-4 mb-1">
+                        <div class="icon icon-team-a"></div>
+                        <span>Team A</span>
+                    </h6>
+                    <ul class="nav flex-column mb-2">
+                        {{#each @root.players.[1]}}
+                        <li class="nav-item">
+                            <a class="nav-link" href="p{{id}}.html">
+                                {{name}}
+                            </a>
+                        </li>
+                        {{/each}}
+                    </ul>
+
+                    <h6 class="sidebar-heading px-3 mt-4 mb-1">
+                        <div class="icon icon-team-b"></div>
+                        <span>Team B</span>
+                    </h6>
+                    <ul class="nav flex-column mb-2">
+                       {{#each @root.players.[2]}}
+                        <li class="nav-item">
+                            <a class="nav-link" href="p{{id}}.html">
+                                {{name}}
+                            </a>
+                        </li>
+                        {{/each}}
+                    </ul>
+                </div>
+            </nav>
+
+            <main id="player-details" role="main" class="col-sm-9 ml-sm-auto col-lg-10 px-4">
+                <p class="h2">Flag pace</p>
+                <div class="chart">
+                    {{{chartMarkup}}}
+                </div>
+            </main>
+        </div>
+    </div>
+
+
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49"
+        crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
+        crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/src/html/template-summary-player.html
+++ b/src/html/template-summary-player.html
@@ -47,7 +47,7 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="index.html">
+                            <a class="nav-link" href="flag-pace.html">
                                 Flag pace
                             </a>
                         </li>

--- a/src/html/template-summary-player.html
+++ b/src/html/template-summary-player.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8" />
 
-    <title>Hampalyzer TFC Stats: {{player}} statistics on {{map}} at {{server}} ({{date}}, {{time}})</title>
+    <title>Hampalyzer TFC Stats: {{name}} statistics on {{map}} at {{server}} ({{date}}, {{time}})</title>
 
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
 
@@ -37,7 +37,7 @@
                             <span>Overall statistics</span>
                         </h6>
                         <li class="nav-item">
-                            <a class="nav-link active" href="index.html">
+                            <a class="nav-link" href="index.html">
                                 Stats by round
                             </a>
                         </li>
@@ -60,7 +60,7 @@
                     <ul class="nav flex-column mb-2">
                         {{#each @root.players.[1]}}
                         <li class="nav-item">
-                            <a class="nav-link" href="p{{id}}.html">
+                            <a class="nav-link{{#ifCondition id '==' ../id}} active{{/ifCondition}}" href="p{{id}}.html">
                                 {{name}}
                             </a>
                         </li>
@@ -74,7 +74,7 @@
                     <ul class="nav flex-column mb-2">
                        {{#each @root.players.[2]}}
                         <li class="nav-item">
-                            <a class="nav-link" href="p{{id}}.html">
+                            <a class="nav-link{{#ifCondition id '==' ../id}} active{{/ifCondition}}" href="p{{id}}.html">
                                 {{name}}
                             </a>
                         </li>

--- a/src/html/template-summary.html
+++ b/src/html/template-summary.html
@@ -203,20 +203,21 @@
                         <table class="table table-borderless table-sm summary summary-offense">
                             <thead>
                                 <tr>
-                                    <th>Team</th>
-                                    <th><abbr title="Kills - TK + SG">Frags</abbr></th>
-                                    <th>Kills</th>
-                                    <th><abbr title="Team kills">TK</abbr></th>
-                                    <th><abbr title="Sentry gun kills">SG</abbr></th>
-                                    <th><abbr title="Enemy + Self + Team">Deaths</abbr></th>
-                                    <th><abbr title="Deaths by enemy">Enemy</abbr></th>
-                                    <th><abbr title="Deaths by suicide">Self</abbr></th>
-                                    <th><abbr title="Deaths by teammate">Team</abbr></th>
-                                    <th><abbr title="Concussion grenades used">Concs</abbr></th>
-                                    <th><abbr title="Captured Flags/Goals">Caps</abbr></th>
-                                    <th><abbr title="Flag/Goal Touches">Touch</abbr></th>
-                                    <th><abbr title="% of Flag Carries Ended in Tosses">Toss %</abbr></th>
-                                    <th>Flag Time</th>
+                                    <th class="team">Team</th>
+                                    <th class="kills-total"><abbr title="Kills - TK + SG">Frags</abbr></th>
+                                    <th class="kills">Kills</th>
+                                    <th class="team-kills"><abbr title="Team kills">TK</abbr></th>
+                                    <th class="conc-kills"><abbr title="Conc kills">CK</abbr></th>
+                                    <th class="sentry-kills"><abbr title="Sentry gun kills">SG</abbr></th>
+                                    <th class="deaths-total"><abbr title="Enemy + Self + Team">Deaths</abbr></th>
+                                    <th class="deaths"><abbr title="Deaths by enemy">Enemy</abbr></th>
+                                    <th class="suicides"><abbr title="Deaths by suicide">Self</abbr></th>
+                                    <th class="team-deaths"><abbr title="Deaths by teammate">Team</abbr></th>
+                                    <th class="concs"><abbr title="Concussion grenades used">Concs</abbr></th>
+                                    <th class="flag-captures"><abbr title="Captured Flags/Goals">Caps</abbr></th>
+                                    <th class="flag-touches"><abbr title="Flag/Goal Touches">Touch</abbr></th>
+                                    <th class="flag-toss-percentage"><abbr title="% of Flag Carries Ended in Tosses">Toss %</abbr></th>
+                                    <th class="flag-time">Flag Time</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -231,15 +232,16 @@
                         <table class="table table-borderless table-sm summary summary-defense">
                             <thead>
                                 <tr>
-                                    <th>Team</th>
-                                    <th><abbr title="Kills - TK + SG">Frags</abbr></th>
-                                    <th>Kills</th>
-                                    <th><abbr title="Team-Kills">TK</abbr></th>
-                                    <th>Deaths</th>
-                                    <th><abbr title="Enemy death">Enemy</abbr></th>
-                                    <th><abbr title="Suicides">Self</abbr></th>
-                                    <th><abbr title="Team-Deaths">Team</abbr></th>
-                                    <th>Airshots</th>
+                                    <th class="team">Team</th>
+                                    <th class="kills-total"><abbr title="Kills - TK + SG">Frags</abbr></th>
+                                    <th class="kills">Kills</th>
+                                    <th class="team-kills"><abbr title="Team-Kills">TK</abbr></th>
+                                    <th class="conc-kills"><abbr title="Conc kills">CK</abbr></th>
+                                    <th class="deaths-total"><abbr title="Enemy + Self + Team">Deaths</abbr></th>
+                                    <th class="deaths"><abbr title="Enemy death">Enemy</abbr></th>
+                                    <th class="suicides"><abbr title="Suicides">Self</abbr></th>
+                                    <th class="team-deaths"><abbr title="Team-Deaths">Team</abbr></th>
+                                    <th class="airshots">Airshots</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/html/template-summary.html
+++ b/src/html/template-summary.html
@@ -50,7 +50,7 @@
                         </li>
                         {{/if}}
                         <li class="nav-item">
-                            <a class="nav-link" href="index.html#flag">
+                            <a class="nav-link" href="flag-pace.html">
                                 Flag pace
                             </a>
                         </li>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-import app from './App';
-import { Parser } from './parser';
-import fileParser from './fileParser';
-import App from './App';
+import { Parser } from './parser.js';
+import fileParser from './fileParser.js';
+import App from './App.js';
 
 import { existsSync } from 'fs';
-import path = require('path');
+import * as path from 'path';
 
 const port = process.env.PORT || 3000;
 

--- a/src/parserUtils.ts
+++ b/src/parserUtils.ts
@@ -1,8 +1,8 @@
-import PlayerList from "./playerList";
-import { Event, RoundParser } from "./parser";
-import Player from "./player";
-import { TeamColor, OutputStats, PlayerClass, TeamStatsComparison, TeamRole, TeamStats, OffenseTeamStats, DefenseTeamStats, OutputPlayer, PlayerOutputStatsRound, TeamsOutputStatsDetailed, GenericStat, ClassTime, TeamOutputStatsDetailed, StatDetails, FacetedStat, EventDescriptor, Weapon, FacetedStatSummary } from "./constants";
-import EventType from "./eventType";
+import PlayerList from "./playerList.js";
+import { Event, RoundParser } from "./parser.js";
+import Player from "./player.js";
+import { TeamColor, OutputStats, PlayerClass, TeamStatsComparison, TeamRole, TeamStats, OffenseTeamStats, DefenseTeamStats, OutputPlayer, PlayerOutputStatsRound, TeamsOutputStatsDetailed, GenericStat, ClassTime, TeamOutputStatsDetailed, StatDetails, FacetedStat, EventDescriptor, Weapon, FacetedStatSummary, TeamFlagMovements, FlagMovement, FlagDrop } from "./constants.js";
+import EventType from "./eventType.js";
 
 export type TeamComposition<TPlayer = Player> = { [team in TeamColor]?: TPlayer[]; };
 export type TeamScore = { [team in TeamColor]?: number; };
@@ -124,33 +124,71 @@ export default class ParserUtils {
         return arr.length;
     }
 
-    public static getScore(events: Event[], teams?: TeamComposition): TeamScore {
+    public static getScoreAndFlagMovements(events: Event[], teams?: TeamComposition): [TeamScore, TeamFlagMovements] {
         const teamScoreEvents = events.filter(ev => ev.eventType === EventType.TeamScore);
         let scores: TeamScore = {};
+        let flagMovements: TeamFlagMovements = {};
 
+        let needToComputeTeamScore = true;
         teamScoreEvents.forEach(event => {
             const team = event.data && event.data.team;
             const score = event.data && event.data.value;
             if (!team) throw "expected team with a teamScore event";
             if (!score) throw "expected value with a teamScore event";
             scores[team] = Number(score);
+            needToComputeTeamScore = false;
         });
 
-        // maybe the server crashed before finishing the log?  fallback to counting caps
-        if (Object.keys(scores).length === 0 && teams) {
-            console.warn("Can't find ending score, manually counting caps...");
-
+        if (teams) {
             const flagCapEvents = events.filter(ev => ev.eventType === EventType.PlayerCapturedFlag);
+            let pointsPerCap = 10;
+            if (!needToComputeTeamScore) { // TODO: add map-specific logic for c2c bonuses, e.g. raiden
+                const firstTeamFlagCapEvents = events.filter(ev => {
+                    return ev.eventType === EventType.PlayerCapturedFlag
+                        && (ParserUtils.getTeamForPlayer(ev.playerFrom!, teams) == 1)
+                });
+                pointsPerCap = scores[1] ?
+                    (firstTeamFlagCapEvents.length > 0 ?
+                        (scores[1] / firstTeamFlagCapEvents.length) : pointsPerCap)
+                    : pointsPerCap;
+                if (pointsPerCap != 10) {
+                    console.warn(`Points per cap is ${pointsPerCap}`);
+                }
+            }
+
+            if (needToComputeTeamScore) { // maybe the server crashed before finishing the log?
+                console.warn("Can't find ending score, manually counting caps...");
+            }
+            let runningScore: TeamScore = {};
             flagCapEvents.forEach(event => {
                 const player = event.playerFrom!;
                 const team = ParserUtils.getTeamForPlayer(player, teams);
 
-                let teamScore = scores[team] || 0;
-                scores[team] = teamScore + 10;
+                if (!flagMovements[team]) {
+                    const teamFlagStats: FlagMovement[] = [];
+                    flagMovements[team] = teamFlagStats;
+                    runningScore[team] = 0;
+                }
+                if (!runningScore[team]) {
+                    runningScore[team] = 0;
+                }
+                runningScore[team] += pointsPerCap;
+                const flagMovement: FlagMovement = {
+                    game_time_as_seconds: event.gameTimeAsSeconds!,
+                    player: player.name,
+                    current_score: runningScore[team],
+                    how_dropped: FlagDrop.Captured,
+
+                }
+                flagMovements[team].push(flagMovement);
+
+                if (needToComputeTeamScore) { // only overwrite the team score if there was no teamScore event
+                    scores[team] = runningScore[team];
+                }
             });
         }
 
-        return scores;
+        return [scores, flagMovements];
     }
 
     public static getPlayerStats(events: Event[], teams: TeamComposition): PlayersStats {
@@ -463,16 +501,14 @@ export default class ParserUtils {
         const parse_name = [serverShortName, year, month, dayOfMonth, time.replace(":", "-")].join("-");
 
         // game time (should we calculate this somewhere else?)
-        const prematchEndEvent = events.find(event => event.eventType === EventType.PrematchEnd);
-        const matchEndEvent = events.find(event => event.eventType === EventType.TeamScore);
+        const matchStartEvent = events.find(event => event.eventType === EventType.PrematchEnd) || events[0];
+        const matchEndEvent = events.find(event => event.eventType === EventType.TeamScore) || events[events.length - 1];
 
-        const matchStart = prematchEndEvent && prematchEndEvent.timestamp || firstTimestamp;
-        const matchEnd = matchEndEvent && matchEndEvent.timestamp || events[events.length - 1].timestamp;
         const gameTime = Intl.DateTimeFormat('en-US', { minute: '2-digit', second: '2-digit' })
-            .format(matchEnd.valueOf() - matchStart.valueOf());
+            .format(matchEndEvent.timestamp.valueOf() - matchStartEvent.timestamp.valueOf());
 
-        const teams = this.generateOutputTeamsStatsDetailed(stats, playerList, teamComp, matchEnd);
-        const score = this.getScore(events, teamComp);
+        const teams = this.generateOutputTeamsStatsDetailed(stats, playerList, teamComp, matchEndEvent.timestamp);
+        const [score, flagMovements] = this.getScoreAndFlagMovements(events, teamComp);
 
         return {
             parse_name,
@@ -485,6 +521,10 @@ export default class ParserUtils {
             server,
             teams,
             score,
+            scoring_activity: {
+                flag_movements: flagMovements,
+                game_time_as_seconds: matchEndEvent.gameTimeAsSeconds ? matchEndEvent.gameTimeAsSeconds : 0
+            }
         };
     }
 
@@ -588,7 +628,7 @@ export default class ParserUtils {
                 }
 
                 // flag statistics (requires holistic view of flag movement)
-                const [flag_time, toss_percent, touches_initial] = this.calculatePlayerFlagStats(thisPlayer, playerStats, stats.flag, matchEnd);
+                const [flag_time, toss_percent, touches_initial] = this.calculatePlayerFlagStats(thisPlayer, playerStats, teams, stats.flag, matchEnd);
                 this.ensureStat<string>(poStats, 'objectives', 'flag_time').value = flag_time;
                 this.ensureStat(poStats, 'objectives', 'toss_percent').value = toss_percent;
                 this.ensureStat(poStats, 'objectives', 'touches_initial').value = touches_initial;
@@ -811,7 +851,7 @@ export default class ParserUtils {
     }
 
     private static getTime(e: Event): string {
-        return Intl.DateTimeFormat('en-us', { minute: 'numeric', second: '2-digit' }).format(e.gametime);
+        return Intl.DateTimeFormat('en-us', { minute: 'numeric', second: '2-digit' }).format(e.gameTimeAsSeconds! * 1000);
     }
 
     private static getSummarizedStat(playerStats: PlayerOutputStatsRound, category: string, item: string): number {
@@ -897,7 +937,7 @@ export default class ParserUtils {
         return [offenseDiff, defenseDiff];
     }
 
-    private static calculatePlayerFlagStats(thisPlayer: Player, playerEvents: Stats, flagEvents: Stats, matchEnd: Date): [string, number, number] {
+    private static calculatePlayerFlagStats(thisPlayer: Player, playerEvents: Stats, teams: TeamComposition, flagEvents: Stats, matchEnd: Date): [string, number, number] {
         // Capture and pickup events are passed in via flagEvents;
         // also use 'team_death'/'death', and 'flag_thrown' events to calculate flag time.
         const deaths = playerEvents['death'];
@@ -930,8 +970,16 @@ export default class ParserUtils {
             if (eventType === EventType.FlagReturn) {
                 return [null, undefined];
             }
+            
+            if ((eventType === EventType.PlayerCapturedFlag || eventType === EventType.PlayerPickedUpFlag)
+                && !this.playersOnSameTeam(teams, thisPlayer, thisEvent.playerFrom!)) {
+                // this is a flag event associated with the other team; ignore it
+                return flagStatus;
+            }
+
             // the flag was captured; record the time if it was this player and set state to null
             if (eventType === EventType.PlayerCapturedFlag) {
+
                 if (thisEvent.playerFrom?.matches(thisPlayer)) {
                     if (!flagStatus[1]!.playerFrom!.matches(thisPlayer)) {
                         console.error("Flag cap seen by a player (" + thisPlayer.name +") which wasn't carrying the flag"

--- a/src/playerList.ts
+++ b/src/playerList.ts
@@ -1,5 +1,5 @@
-import Player from './player';
-import { TeamColor } from './constants';
+import Player from './player.js';
+import { TeamColor } from './constants.js';
 
 class PlayerList {
     private _players: Player[];

--- a/src/templateUtils.ts
+++ b/src/templateUtils.ts
@@ -1,4 +1,4 @@
-import * as Handlebars from 'handlebars';
+import Handlebars from 'handlebars';
 import { OffenseTeamStats, DefenseTeamStats, OutputPlayer } from './constants';
 import { isNumber } from 'util';
 
@@ -54,20 +54,21 @@ export default class TemplateUtils {
             const isComparison = teamId === 'Comp'; // first parameter can sometimes be object??
             return `
                 <tr ${isComparison && 'class="comp"'}>
-                    <td>${TemplateUtils.getTeamName(teamId, players)}</td>
-                    ${TemplateUtils.getRow(this.frags, isComparison)}
-                    ${TemplateUtils.getRow(this.kills, isComparison)}
-                    ${TemplateUtils.getRow(this.team_kills, isComparison)}
-                    ${TemplateUtils.getRow(this.sg_kills, isComparison)}
-                    ${TemplateUtils.getRow(this.deaths, isComparison)}
-                    ${TemplateUtils.getRow(this.d_enemy, isComparison)}
-                    ${TemplateUtils.getRow(this.d_self, isComparison)}
-                    ${TemplateUtils.getRow(this.d_team, isComparison)}
-                    ${TemplateUtils.getRow(this.concs, isComparison)}
-                    ${TemplateUtils.getRow(this.caps, isComparison)}
-                    ${TemplateUtils.getRow(this.touches, isComparison)}
-                    ${TemplateUtils.getRow(this.toss_percent, isComparison)}
-                    ${TemplateUtils.getRow(this.flag_time, isComparison)}
+                    <td class="team">${TemplateUtils.getTeamName(teamId, players)}</td>
+                    ${TemplateUtils.getRow(this.frags, isComparison, "kills-total")}
+                    ${TemplateUtils.getRow(this.kills, isComparison, "kills")}
+                    ${TemplateUtils.getRow(this.team_kills, isComparison, "team-kills")}
+                    ${TemplateUtils.getRow(this.conc_kills, isComparison, "conc-kills")}
+                    ${TemplateUtils.getRow(this.sg_kills, isComparison, "sentry-kills")}
+                    ${TemplateUtils.getRow(this.deaths, isComparison, "deaths-total")}
+                    ${TemplateUtils.getRow(this.d_enemy, isComparison, "deaths")}
+                    ${TemplateUtils.getRow(this.d_self, isComparison, "suicides")}
+                    ${TemplateUtils.getRow(this.d_team, isComparison, "team-deaths")}
+                    ${TemplateUtils.getRow(this.concs, isComparison, "concs")}
+                    ${TemplateUtils.getRow(this.caps, isComparison, "flag-captures")}
+                    ${TemplateUtils.getRow(this.touches, isComparison, "flag-touches")}
+                    ${TemplateUtils.getRow(this.toss_percent, isComparison, "flag-toss-percentage")}
+                    ${TemplateUtils.getRow(this.flag_time, isComparison, "flag-time")}
                 </tr>`;
         });
 
@@ -75,15 +76,16 @@ export default class TemplateUtils {
             const isComparison = teamId === 'Comp'; // first parameter can sometimes be object??
             return `
                 <tr ${isComparison && 'class="comp"'}>
-                    <td>${TemplateUtils.getTeamName(teamId, players)}</td>
-                    ${TemplateUtils.getRow(this.frags, isComparison)}
-                    ${TemplateUtils.getRow(this.kills, isComparison)}
-                    ${TemplateUtils.getRow(this.team_kills, isComparison)}
-                    ${TemplateUtils.getRow(this.deaths, isComparison)}
-                    ${TemplateUtils.getRow(this.d_enemy, isComparison)}
-                    ${TemplateUtils.getRow(this.d_self, isComparison)}
-                    ${TemplateUtils.getRow(this.d_team, isComparison)}
-                    ${TemplateUtils.getRow(this.airshots, isComparison)}
+                    <td class="team">${TemplateUtils.getTeamName(teamId, players)}</td>
+                    ${TemplateUtils.getRow(this.frags, isComparison, "kills-total")}
+                    ${TemplateUtils.getRow(this.kills, isComparison, "kills")}
+                    ${TemplateUtils.getRow(this.team_kills, isComparison, "team-kills")}
+                    ${TemplateUtils.getRow(this.conc_kills, isComparison, "conc-kills")}
+                    ${TemplateUtils.getRow(this.deaths, isComparison, "deaths-total")}
+                    ${TemplateUtils.getRow(this.d_enemy, isComparison, "deaths")}
+                    ${TemplateUtils.getRow(this.d_self, isComparison, "suicides")}
+                    ${TemplateUtils.getRow(this.d_team, isComparison, "team-deaths")}
+                    ${TemplateUtils.getRow(this.airshots, isComparison, "airshots")}
                 </tr>`;
         });
     }
@@ -105,22 +107,23 @@ export default class TemplateUtils {
         return toReturn;
     }
 
-    static getRow(value: number | string, isComparison: boolean): string {
+    static getRow(value: number | string, isComparison: boolean, cssClassName: string | undefined): string {
+        const baseClassAttributeValue = cssClassName ? `${cssClassName} ` : "";
         if (!isComparison || value === 0)
-            return `<td>${value}</td>`;
+            return `<td class="${baseClassAttributeValue}">${value}</td>`;
         if (typeof value === 'number') {
             if (value > 0)
-                return `<td class="up icon">${value}</td>`;
+                return `<td class="${baseClassAttributeValue}up icon">${value}</td>`;
             else // if (value < 0)
-                return `<td class="down icon">${Math.abs(value)}</td>`;
+                return `<td class="${baseClassAttributeValue}down icon">${Math.abs(value)}</td>`;
         } else {
             // if first character is "-", consider it 'negative'
             if (value.charAt(0) === "-")
-                return `<td class="down icon">${value.slice(1)}</td>`;
+                return `<td class="${baseClassAttributeValue}down icon">${value.slice(1)}</td>`;
             else if (!isNaN(parseInt(value.charAt(0))))
-                return `<td class="up icon">${value}</td>`;
+                return `<td class="${baseClassAttributeValue}up icon">${value}</td>`;
             else
-                return `<td>${value}</td>`;
+                return `<td class="${baseClassAttributeValue}">${value}</td>`;
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
+        "module": "ES2020",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "target": "ES2020",
         "noImplicitAny": false,
         "sourceMap": true,
         "outDir": "./dist/",
-        "strict": true,
+        "strict": true
     },
     "files": [
         "./node_modules/@types/node/index.d.ts",


### PR DESCRIPTION
This change primarily adds a "flag pace" page that shows a graph of scores over round time. It uses d3js running in the Node environment to statically create the SVG markup and pass it to the template.

In order to use d3js from within Node, I had to move the to ES Modules in Node instead of CommonJS. A variety of small changes were made to support that.

Other misc. fixes/improvements:
* Fix flag time handling for when both teams have flag movement (e.g. as would happen in an 8v8)
* Add conc kills column to O/D comparisons on summary page
* Fix O/D comparison CSS styling