### PR TITLE
Add support for fry_complex lasers

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1075,6 +1075,7 @@ export class Event {
             case "the blue team's lasers (world)": // orbit_l3
             case "env_beam (world)": // stormz2
             case "rock_laser_kill (world)": // baconbowl
+            case "info_tfgoal (world)": // fry_complex
                 return Weapon.Lasers;
             case "train":
             case "train (world)":


### PR DESCRIPTION
Fixes #35 (fry_complex lasers had an unexpected name which was not handled, this adds it to the Weapon.Lasers bucket).