### PR TITLE
Add support for Rasen team names

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -948,11 +948,13 @@ export class Event {
             case "blue :d?": // destroy_l
             case "dustbowl_team1": // baconbowl
             case "attackers": // attac
+            case "#dustbowl_team1": // rasen
                 return TeamColor.Blue;
             case "red":
             case "red :d?": // destroy_l
             case "dustbowl_team2": // baconbowl
             case "defenders": // attac
+            case "#dustbowl_team2": // rasen
                 return TeamColor.Red;
             case "yellow":
                 return TeamColor.Yellow;


### PR DESCRIPTION
Fixes #37 by adding the Rasen-specific team names to the case lists.

Tested locally (and retested after resyncing with latest hampalyzer), appears to successfully parse the Rasen log files without any further issues.