### PR TITLE
Improving support for Magelli and Osaka

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -563,10 +563,22 @@ export class Event {
                                     case "Flag 4":
                                         eventType = EventType.PlayerPickedUpFlag;
                                         break;
+                                    case "Flag #1": // osaka
+                                    case "Flag #2":
+                                    case "Flag #3":
+                                    case "Flag #4":
+                                        eventType = EventType.PlayerPickedUpFlag;
+                                        break;
                                     case "Capture Point 1": // cornfield
                                     case "Capture Point 2":
                                     case "Capture Point 3":
                                     case "Capture Point 4":
+                                        eventType = EventType.PlayerCapturedFlag;
+                                        break;
+                                    case "capture point 1": // magelli
+                                    case "capture point 2":
+                                    case "capture point 3":
+                                    case "capture point 4":
                                         eventType = EventType.PlayerCapturedFlag;
                                         break;
                                     case "Team 1 dropoff":
@@ -637,6 +649,7 @@ export class Event {
                                     case 'red_det': // 2mesa3 / stowaway2 water opened
                                     case 'blue_det':
                                     case 'rholedet': // cornfield cp4 / avanti
+                                    case 'det1detect': // magelli
                                         if (nonPlayerDataParts.length === 2)
                                             eventType = EventType.PlayerOpenedDetpackEntrance;
                                         else
@@ -690,6 +703,25 @@ export class Event {
                                     case 'RED_SPAWN_three': // mulch_trench respawn?
                                     case 'RED_SPAWN_ONE': // mulch_trench_lg respawn
                                     // case 'grenbackpack': // ??
+                                    case "ammo_giver": // osaka spawn trigger
+                                    case "Blue team spawn stuff 1": // magelli spawn trigger
+                                    case "Blue team spawn stuff 2": // magelli spawn trigger
+                                    case "Blue team spawn stuff 3": // magelli spawn trigger
+                                    case "Red team spawn stuff 1": // magelli spawn trigger
+                                    case "Red team spawn stuff 2": // magelli spawn trigger
+                                    case "Red team spawn stuff 3": // magelli spawn trigger
+                                    case "warning sound1": // magelli message handling
+                                    case "warning sound2": // magelli message handling
+                                    case "warning sound3": // magelli message handling
+                                    case "warning sound4": // magelli message handling
+                                    case "Spawn mover 1": // magelli helper entity
+                                    case "Spawn mover 2": // magelli helper entity
+                                    case "Flag mover 1": // magelli helper entity
+                                    case "Flag mover 2": // magelli helper entity
+                                    case "attackers win": // magelli (already handled by Cease_Fire? TODO: investigate this)
+                                    case "Reset spawns": // magelli (already handled by Cease_Fire? TODO: investigate this)
+                                    case "reset flag": // magelli (already handled by Cease_Fire? TODO: investigate this)
+                                    case "Start message": // magelli (can be player or world, already handled by #dustbowl_gates_open)
                                         return;
                                     default:
                                         console.error(`unknown player trigger: ${nonPlayerDataParts[1]}: ${lineData}`);
@@ -833,10 +865,17 @@ export class Event {
                                 case "Red security will be operational in 30 seconds!": // schtop
                                 case "Blue_Flag_Vox":
                                 case "Red_Flag_Vox":
+                                case "#dustbowl_90_secs": // magelli
                                 case "#dustbowl_60_secs": // dustbowl / cornfield
                                 case "#dustbowl_30_secs": // dustbowl / cornfield
                                 case "#dustbowl_10_secs": // dustbowl / cornfield
                                 case "defenders_score": // adl-specific score for time held (e.g., cornfield)
+                                case "Defender score timer": // magelli
+                                case "warning sound1": // magelli
+                                case "warning sound2": // magelli
+                                case "warning sound3": // magelli
+                                case "warning sound4": // magelli
+                                case "Start message": // magelli (can be player or world, already handled by #dustbowl_gates_open)
                                 case "Command Point 4 Wall Breached": // cornfield (already handled by rholedet)
                                 case "Command Point Four breached!": // avanti(?) (already handled by rholedet)
                                 case "#italy_hole_text": // avanti (already handled by rholedet)
@@ -949,12 +988,14 @@ export class Event {
             case "dustbowl_team1": // baconbowl
             case "attackers": // attac
             case "#dustbowl_team1": // rasen
+            case "goto clan": // osaka
                 return TeamColor.Blue;
             case "red":
             case "red :d?": // destroy_l
             case "dustbowl_team2": // baconbowl
             case "defenders": // attac
             case "#dustbowl_team2": // rasen
+            case "ii clan": // osaka
                 return TeamColor.Red;
             case "yellow":
                 return TeamColor.Yellow;


### PR DESCRIPTION
Fixes #41 (and tries to help with other magelli issues, and some related osaka issues).

Added handling for:
- `"goto clan"` as TeamColor.Blue (osaka)
- `"ii clan"` as TeamColor.Red (osaka)
- Ignore Player trigger for `"ammo_giver"` (osaka)
- Use PlayerPickedUpFlag for Player triggers like `"Flag #1"`, `"Flag #2"` etc (osaka)
- Use PlayerCapturedFlag for Player triggers like `"capture point 1"`, `"capture point 2"` etc (magelli)
- Use PlayerOpenedDetpackEntrance for Player triggers like `'det1detect'` (magelli)
- Ignore Player triggers like `"Blue team spawn stuff 1"`, `"Red team spawn stuff 2"` etc (magelli)
- Ignore Player triggers like `"Spawn mover 1"`, `"Spawn mover 2"` etc (magelli)
- Ignore Player triggers like `"flag mover 1"`, `"flag mover 2"` etc (magelli)
- Ignore Player triggers like `"attackers win"`, `"Reset spawns"`, and `"reset flag"`, because I **THINK** these are all redundant with `Cease_Fire`, but magelli also uses multiple `Cease_Fire` per side swap so I'm not sure how that works out... (magelli)
- Ignore Player AND World triggers for `"Start message"` (magelli)
- Ignore Player AND World triggers like `"warning sound1"`, `"warning sound2"` etc (magelli)
- Ignore World trigger `"dustbowl_90_secs"` (magelli)
- Ignore World trigger `"Defender score timer"` (magelli)

**Not** handled:
- World triggers for `"#dustbowl_flag_returned"` and/or `"Flag has returned Info"` (see #39)
- Ban messages like `"<><STEAM_0:0:0><>" was banned "permanently" by "Console"`
- AMX mod messages like `[AMX] Server triggered  "Deployed_CTF_Flag_Timer"`

Other:
There were several messages like `didn't count event id PlayerFraggedTeleporter for Soap against OST-CyKo Dad` that I wasn't sure what to do with.
There were also a bunch of `generateStatDetails: not implemented: objectives > det_entrance` type messages, but those were colored blue so I assume they're fine :D