### PR TITLE
Add parsing errors to full game template

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -7,23 +7,9 @@ import pg from 'pg';
 import { readFileSync } from 'fs';
 import path from 'path';
 
-import { default as fileParser, HampalyzerTemplates, ParsedPath } from './fileParser.js';
-import { isParsedStats, ParsedStats, Parser } from './parser.js';
+import { default as fileParser, HampalyzerTemplates } from './fileParser.js';
+import { ParsedStats, Parser } from './parser.js';
 import TemplateUtils from './templateUtils.js';
-
-type ParsedResult = ParsedPath | ParsedError;
-
-interface ParsedError {
-    error: string;
-}
-
-function isParsedError(parsedError: ParsedResult): parsedError is ParsedError {
-    if ((parsedError as ParsedError).error !== undefined)
-        return true;
-
-    return false;
-}
-
 // see https://github.com/expressjs/multer
 // and https://medium.com/@petehouston/upload-files-with-curl-93064dcccc76
 // and ...?
@@ -99,12 +85,11 @@ class App {
 
             if (parsedResult == null) {
                 res.status(500).json({ error: "Failed to parse file (please pass logs to Hampster)" });
-            } else if (isParsedError(parsedResult)) {
-                res.status(500).json({ error: parsedResult.error })
-            } else {
+            }
+            else {
                 // sanitize the outputPath by removing the webserverRoot path
                 // (e.g., remove /var/www/app.hampalyzer.com/html prefix)
-                let outputPath = parsedResult.path;
+                let outputPath = parsedResult;
                 if (outputPath.startsWith(this.webserverRoot)) {
                     outputPath = outputPath.slice(this.webserverRoot.length);
                 }
@@ -120,12 +105,11 @@ class App {
 
             if (parsedResult == null) {
                 res.status(500).json({ error: "Failed to parse file (please pass logs to Hampster)" });
-            } else if (isParsedError(parsedResult)) {
-                res.status(500).json({ error: parsedResult.error })
-            } else {
+            }
+            else {
                 // sanitize the outputPath by removing the webserverRoot path
                 // (e.g., remove /var/www/app.hampalyzer.com/html prefix)
-                let outputPath = parsedResult.path;
+                let outputPath = parsedResult;
                 if (outputPath.startsWith(this.webserverRoot)) {
                     outputPath = outputPath.slice(this.webserverRoot.length);
                 }
@@ -173,8 +157,8 @@ class App {
                 console.warn(`${i+1} / ${len} (${Math.round((i+1) / len * 1000) / 10}%) reparsing: ${filenames.join(" +  ")}`);
 
                 const parsedLog = await this.parseLogs(filenames, true /* reparse */);
-                if (!parsedLog || isParsedError(parsedLog)) {
-                    console.error(`failed to parse logs ${filenames.join(" + ")} for reason: ${parsedLog?.error}; aborting`);
+                if (!parsedLog) {
+                    console.error(`failed to parse logs ${filenames.join(" + ")}; aborting`);
                     return false;
                 }
             }
@@ -186,19 +170,11 @@ class App {
         return result && result.rows.length !== 0;
     }
 
-    private parseLogs(filenames: string[], reparse?: boolean): Promise<ParsedResult | undefined> {
+    private parseLogs(filenames: string[], reparse?: boolean): Promise<string | undefined> {
         const parser = new Parser(...filenames)
 
         return parser.parseRounds()
-            .then(
-                allStats => {
-                    if (isParsedStats(allStats))
-                        return fileParser(allStats, path.join(this.webserverRoot, this.outputRoot), this.templates, this.pool, reparse);
-
-                    // return { error: "An unknown, unthrown error occurred" };
-                },
-                (error: string) => ({ error })
-            );
+            .then(allStats => fileParser(allStats, path.join(this.webserverRoot, this.outputRoot), this.templates, this.pool, reparse));
     }
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export interface OutputStats {
     teams: TeamsOutputStatsDetailed;
     scoring_activity?: ScoringActivity;
     damage_stats_exist: boolean;
+    parsing_errors?: string[];
 }
 
 // expected to be ordered by timestamp ascending

--- a/src/fileParser.ts
+++ b/src/fileParser.ts
@@ -24,13 +24,17 @@ export interface HampalyzerTemplates {
     player: HandlebarsTemplateDelegate<any>;
 }
 
+export interface ParsedPath {
+    path: string
+};
+
 export default async function(
     allStats: ParsedStats | undefined,
     outputRoot: string = 'parsedlogs',
     templates?: HampalyzerTemplates,
     pool?: pg.Pool,
     reparse?: boolean,
-    ): Promise<string | undefined> {
+    ): Promise<ParsedPath | undefined> {
 
     if (allStats) {
         const matchMeta: MatchMetadata = {
@@ -62,7 +66,9 @@ export default async function(
         if (!reparse) {
             const isDuplicate = await checkHasDuplicate(pool, matchMeta);
             console.log('isDuplicate', isDuplicate);
-            if (isDuplicate) return `${outputRoot}/${matchMeta.logName}`;
+            if (isDuplicate) {
+                return { path: `${outputRoot}/${matchMeta.logName}` };
+            }
         }
 
         const logName = await getLogName(pool, allStats.stats[0]!.parse_name, reparse);
@@ -156,7 +162,9 @@ export default async function(
 
         // Append a forward slash to ensure we skip the nginx redirect which adds it anyway.
         // (which, when the server name had a '?', decodes %3F back into '?' which in turn results in a 404)
-        return (dbSuccess || reparse) ? `${outputDir}/` : undefined;
+        return (dbSuccess || reparse) ?
+            { path: `${outputDir}/` } :
+            undefined;
     } else console.error('no stats found to write!');
 }
 

--- a/src/html/template-summary.html
+++ b/src/html/template-summary.html
@@ -53,6 +53,14 @@
                                 Flag pace
                             </a>
                         </li>
+                        {{#ifListNotEmpty ../parsing_errors}}
+                        <li class="nav-item">
+                            <a id="parsing-errors-nav-link" class="nav-link" href="#parsing-errors">
+                                Parsing errors
+                                <span class="badge badge-warning badge-pill">{{countParsingErrors ../parsing_errors}}</span>
+                            </a>
+                        </li>
+                        {{/ifListNotEmpty}}
                     </ul>
 
                     <h6 class="sidebar-heading px-3 mt-4 mb-1">
@@ -274,6 +282,23 @@
                         {{{chartMarkup}}}
                     </div>
                 </div>
+
+                {{#ifListNotEmpty parsing_errors}}
+                <div id="parsing-errors" class="alert alert-warning my-5 col-sm-9" role="alert">
+                    <h4 class="alert-heading">Parsing errors</h4>
+                    <hr>
+                    {{#each parsing_errors}}
+                    {{#if this}}
+                    <h5 class="alert-heading">Round {{math @index "+" 1}}</h5>
+                    <ul class="mb-0">
+                        {{#each this}}
+                        <li>{{this}}</li>
+                        {{/each}}
+                    </ul>
+                    {{/if}}
+                    {{/each}}
+                </div>
+                {{/ifListNotEmpty}}
             </main>
         </div>
     </div>

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -74,7 +74,7 @@ export class RoundParser {
     }
 
     private async parseRound(filename: string): Promise<void> {
-        return new Promise<void>((resolve) => {
+        return new Promise<void>((resolve, reject) => {
             const logStream = fs.createReadStream(filename);
             logStream.on('data', chunk => {
                 this.rawLogData += chunk;
@@ -84,6 +84,7 @@ export class RoundParser {
                 resolve();
             }).on('error', (error) => {
                 console.error(error);
+                reject(error);
             });
         });
     }

--- a/src/templateUtils.ts
+++ b/src/templateUtils.ts
@@ -30,6 +30,19 @@ export default class TemplateUtils {
             }
         });
 
+        Handlebars.registerHelper('ifListNotEmpty', function(this: unknown, givenArray: any[][], options) {
+            if (givenArray.length && givenArray.some(item => item.length))
+                return options.fn(this);
+            else
+                return options.inverse(this);
+        });
+
+        Handlebars.registerHelper('countParsingErrors', function(this: unknown, givenArray: any[][]) {
+            if (givenArray.length && givenArray.some(item => item.length)) {
+                return givenArray.reduce((acc, round) => acc + (round.length || 0), 0);
+            }
+        });
+
         // dumping json objects
         Handlebars.registerHelper('json', function(context) {
             return JSON.stringify(context);


### PR DESCRIPTION
Exposes parsing errors to the full game template.  The menu item and the "parsing errors" sections won't show if no errors were found.

Helps to debug issues; don't consider exceptions during event parsing to be critical failure.  Will probably follow-up with another change to do some more sanity checking (no flag captures/touches found, teams don't match enough [incomplete game], etc.)

![image](https://user-images.githubusercontent.com/75544204/185688191-aca3fdfd-e1ad-43e0-8663-162289f3d6d9.png)
