### PR TITLE
Track flag time in seconds and format it at display time

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -103,7 +103,7 @@ export interface PlayerStats {
         flag_touch?: GenericStat<'flag_touch'>;
         flag_capture?: GenericStat<'flag_capture'>;
         flag_capture_bonus?: GenericStat<'flag_capture_bonus'>;
-        flag_time?: GenericStat<'flag_time', string>;
+        flag_time_in_seconds?: GenericStat<'flag_time_in_seconds'>;
         toss_percent?: GenericStat<'toss_percent'>;
         button?:  GenericStat<'button'>;
         det_entrance?: GenericStat<'det_entrance'>;
@@ -174,7 +174,7 @@ export interface OffenseTeamStats extends ITeamStats {
     touches: number;
     touches_initial: number;
     toss_percent: number;
-    flag_time: string;
+    flag_time_in_seconds: number;
     obj?: number;
 }
 

--- a/src/html/template-summary.html
+++ b/src/html/template-summary.html
@@ -176,7 +176,7 @@
                                         <td class="flag-captures">{{#if objectives.flag_capture}}{{objectives.flag_capture.value}}{{#if ../teamStats.caps_bonus}} ({{objectives.flag_capture_bonus.value}}){{/if}}{{else}}--{{/if}}</td>
                                         <td class="flag-touches">{{#if objectives.flag_touch}}{{objectives.flag_touch.value}} ({{objectives.touches_initial.value}}){{else}}--{{/if}}</td>
                                         <td class="flag-toss-percentage">{{#if objectives.flag_touch}}{{#if objectives.toss_percent}}{{objectives.toss_percent.value}}%{{else}}--{{/if}}{{else}}--{{/if}}</td>
-                                        <td class="flag-time">{{Intl.DateTimeFormat('en-us', { minute: 'numeric', second: '2-digit' }).format(objectives.flag_time_in_seconds.value * 1000)}}</td>
+                                        <td class="flag-time">{{formatSecondsForDisplay objectives.flag_time_in_seconds.value}}</td>
                                         <td class="objectives">{{#if objectives.button}}{{objectives.button.value}}{{else}}--{{/if}}</td>
                                     </tr>
                                     {{/each}}
@@ -197,7 +197,7 @@
                                         <td class="flag-captures">{{#if caps}}{{caps}}{{#if caps_bonus}} ({{caps_bonus}}){{/if}}{{else}}--{{/if}}</td>
                                         <td class="flag-touches">{{#if touches}}{{touches}} ({{touches_initial}}){{else}}--{{/if}}</td>
                                         <td class="flag-toss-percentage">{{#if toss_percent}}{{toss_percent}}%{{else}}--{{/if}}</td>
-                                        <td class="flag-time">{{#if flag_time_in_seconds}}{{flag_time_in_seconds}}{{else}}--{{/if}}</td>
+                                        <td class="flag-time">{{#if flag_time_in_seconds}}{{formatSecondsForDisplay flag_time_in_seconds}}{{else}}--{{/if}}</td>
                                         <td class="objectives">{{#if obj}}{{obj}}{{else}}--{{/if}}</td>
                                     </tr>
                                     {{/with}}

--- a/src/html/template-summary.html
+++ b/src/html/template-summary.html
@@ -176,7 +176,7 @@
                                         <td class="flag-captures">{{#if objectives.flag_capture}}{{objectives.flag_capture.value}}{{#if ../teamStats.caps_bonus}} ({{objectives.flag_capture_bonus.value}}){{/if}}{{else}}--{{/if}}</td>
                                         <td class="flag-touches">{{#if objectives.flag_touch}}{{objectives.flag_touch.value}} ({{objectives.touches_initial.value}}){{else}}--{{/if}}</td>
                                         <td class="flag-toss-percentage">{{#if objectives.flag_touch}}{{#if objectives.toss_percent}}{{objectives.toss_percent.value}}%{{else}}--{{/if}}{{else}}--{{/if}}</td>
-                                        <td class="flag-time">{{objectives.flag_time.value}}</td>
+                                        <td class="flag-time">{{Intl.DateTimeFormat('en-us', { minute: 'numeric', second: '2-digit' }).format(objectives.flag_time_in_seconds.value * 1000)}}</td>
                                         <td class="objectives">{{#if objectives.button}}{{objectives.button.value}}{{else}}--{{/if}}</td>
                                     </tr>
                                     {{/each}}
@@ -197,7 +197,7 @@
                                         <td class="flag-captures">{{#if caps}}{{caps}}{{#if caps_bonus}} ({{caps_bonus}}){{/if}}{{else}}--{{/if}}</td>
                                         <td class="flag-touches">{{#if touches}}{{touches}} ({{touches_initial}}){{else}}--{{/if}}</td>
                                         <td class="flag-toss-percentage">{{#if toss_percent}}{{toss_percent}}%{{else}}--{{/if}}</td>
-                                        <td class="flag-time">{{#if flag_time}}{{flag_time}}{{else}}--{{/if}}</td>
+                                        <td class="flag-time">{{#if flag_time_in_seconds}}{{flag_time_in_seconds}}{{else}}--{{/if}}</td>
                                         <td class="objectives">{{#if obj}}{{obj}}{{else}}--{{/if}}</td>
                                     </tr>
                                     {{/with}}

--- a/src/templateUtils.ts
+++ b/src/templateUtils.ts
@@ -1,6 +1,5 @@
 import Handlebars from 'handlebars';
 import { OffenseTeamStats, DefenseTeamStats, OutputPlayer } from './constants';
-import { isNumber } from 'util';
 
 export default class TemplateUtils {
     public static registerHelpers() {
@@ -41,6 +40,22 @@ export default class TemplateUtils {
             if (givenArray.length && givenArray.some(item => item.length)) {
                 return givenArray.reduce((acc, round) => acc + (round.length || 0), 0);
             }
+        });
+
+        function formatSecondsForDisplay(seconds: number) {
+            let isNegative = false;
+            if (seconds < 0) {
+                isNegative = true;
+                seconds = Math.abs(seconds);
+            }
+            let formatted = Intl.DateTimeFormat('en-us', { minute: 'numeric', second: '2-digit' }).format(seconds * 1000);
+            if (isNegative) {
+                formatted = '-' + formatted;
+            }
+            return formatted;
+        }
+        Handlebars.registerHelper('formatSecondsForDisplay', function(seconds: number) {
+            return formatSecondsForDisplay(seconds);
         });
 
         // dumping json objects
@@ -84,7 +99,7 @@ export default class TemplateUtils {
                     ${TemplateUtils.getRow(this.caps, isComparison, "flag-captures")}
                     ${TemplateUtils.getRow(this.touches, isComparison, "flag-touches")}
                     ${TemplateUtils.getRow(this.toss_percent, isComparison, "flag-toss-percentage")}
-                    ${TemplateUtils.getRow(this.flag_time, isComparison, "flag-time")}
+                    ${TemplateUtils.getRow(formatSecondsForDisplay(this.flag_time_in_seconds), isComparison, "flag-time")}
                 </tr>`;
         });
 


### PR DESCRIPTION
As seen in http://app.hampalyzer.com/parsedlogs/Inhouse-2022-Aug-29-23-37/, the flag time diff calculation reports the wrong value (01:49 instead of 00:11).

Instead of attempting to fix the diff function, I instead simplified the computations by keeping the flag time as a number (in seconds) all the way up until display time.