### PR TITLE
Automatically compress to Brotli and remove original log

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/express": "^4.16.0",
         "@types/jsdom": "^16.2.13",
         "@types/multer": "^1.4.3",
-        "@types/node": "^10.17.51",
+        "@types/node": "^20.4.9",
         "@types/pg": "^7.14.11"
       }
     },
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "version": "20.4.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
+      "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==",
       "dev": true
     },
     "node_modules/@types/parse5": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/express": "^4.16.0",
     "@types/jsdom": "^16.2.13",
     "@types/multer": "^1.4.3",
-    "@types/node": "^10.17.51",
+    "@types/node": "^20.4.9",
     "@types/pg": "^7.14.11"
   }
 }

--- a/src/App.ts
+++ b/src/App.ts
@@ -7,6 +7,7 @@ import pg from 'pg';
 import { readFileSync } from 'fs';
 import path from 'path';
 
+import { FileCompression } from './fileCompression.js';
 import { default as fileParser, HampalyzerTemplates } from './fileParser.js';
 import { ParsedStats, Parser } from './parser.js';
 import TemplateUtils from './templateUtils.js';
@@ -170,7 +171,8 @@ class App {
         return result && result.rows.length !== 0;
     }
 
-    private parseLogs(filenames: string[], reparse?: boolean): Promise<string | undefined> {
+    private async parseLogs(filenames: string[], reparse?: boolean): Promise<string | undefined> {
+        filenames = await FileCompression.ensureFilesCompressed(filenames, /*deleteOriginals=*/true);
         const parser = new Parser(...filenames)
 
         return parser.parseRounds()

--- a/src/fileCompression.ts
+++ b/src/fileCompression.ts
@@ -21,7 +21,7 @@ export class FileCompression {
         // Check that we can actually access the brotli file before returning that path and/or deleting the original log.
         try {
             await fs.promises.access(filePathWithBrotliExtension, fs.constants.R_OK);
-            
+
             if (shouldCompress && deleteUncompressedFile) {
                 // Double check the file round trips correctly before proceeding with removing the original.
                 if (await this.verifyContentsIdentical(filePath, filePathWithBrotliExtension)) {
@@ -106,7 +106,7 @@ export class FileCompression {
         const uncompressedFileContents = await this.getDecompressedContents(uncompressedFilePath);
         if (uncompressedFileContents.length < 100) {
             // Extra paranoia: confirm the uncompressed file is reasonably large before proceeding.
-            console.error(`verifyContentsIdentical: uncompressed file (${uncompressedFilePath}) smaller than expected (length=${uncompressedFileContents.length})`;
+            console.error(`verifyContentsIdentical: uncompressed file (${uncompressedFilePath}) smaller than expected (length=${uncompressedFileContents.length})`);
             return false;
         }
         const compressedFileContents = await this.getDecompressedContents(compressedFilePath);

--- a/src/fileCompression.ts
+++ b/src/fileCompression.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+import * as zlib from 'zlib';
+import path from 'path';
+import streamPromises from 'stream/promises';
+import stream from 'stream';
+
+export class FileCompression {
+    private static compressedFileExtension = ".br"; // brotli
+
+    public static async ensureFilesCompressed(filePaths: string[], deleteOriginals: boolean): Promise<string[]> {
+       return Promise.all(filePaths.map(path => this.ensurePathIsCompressed(path, deleteOriginals)));
+    }
+
+    // Returns a compressed path for the file (either already existing or newly created)
+    private static async ensurePathIsCompressed(filePath: string, deleteUncompressedFile: boolean): Promise<string> {
+        const filePathWithBrotliExtension = `${filePath}${FileCompression.compressedFileExtension}`;
+        const shouldCompress = await this.shouldCompressFile(filePath);
+        if (shouldCompress) {
+            await this.compressFile(filePath, filePathWithBrotliExtension);
+        }
+        // Check that we can actually access the brotli file before returning that path and/or deleting the original log.
+        try {
+            await fs.promises.access(filePathWithBrotliExtension, fs.constants.R_OK);
+            
+            if (shouldCompress && deleteUncompressedFile) {
+                await fs.promises.unlink(filePath);
+            }
+            return filePathWithBrotliExtension;
+        }
+        catch (err) {
+            console.log(`Could not access ${filePathWithBrotliExtension}: ${err}`)
+            return filePath;
+        }
+    }
+
+    // Returns the path to compress the file to if needed, otherwise undefined.
+    private static async shouldCompressFile(filePath: string): Promise<boolean> {
+        if (path.extname(filePath) === FileCompression.compressedFileExtension) {
+            // Already compressed.
+            return false;
+        }
+        const filePathWithBrotliExtension = `${filePath}${FileCompression.compressedFileExtension}`;
+        try {
+            await fs.promises.access(filePathWithBrotliExtension, fs.constants.R_OK);
+            // Brotli path already exists.
+            return false;
+        }
+        catch (errorFromOpeningBrotliPath) {
+            try {
+                // Check for write access to ensure we'll be able to clean it up afterward.
+                await fs.promises.access(filePath, fs.constants.R_OK | fs.constants.W_OK);
+                // The path is accessible, and needs to be compressed.
+                return true;
+            }
+            catch (error) {
+                console.error(`shouldCompressFile: failed to access ${filePath}.`);
+                return false;
+            }
+        };
+    }
+
+    private static async compressFile(filePath: string, compressedDestinationFilePath: string) {
+        const inputFileSize = fs.statSync(filePath).size;
+
+        const outputCompressedFileStream = fs.createWriteStream(compressedDestinationFilePath);
+
+        const brotliCompressStream = zlib.createBrotliCompress({
+            params: {
+              [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+              [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+              [zlib.constants.BROTLI_PARAM_SIZE_HINT]: inputFileSize,
+            }
+        });
+        await streamPromises.pipeline(fs.createReadStream(filePath), brotliCompressStream, fs.createWriteStream(compressedDestinationFilePath));
+    }
+
+    public static async getDecompressedContents(filePath: string) : Promise<string> {
+        let output = "";
+
+        const pathIsCompressed = path.extname(filePath) === FileCompression.compressedFileExtension;
+        console.log(`File ${filePath} (extension: ${path.extname(filePath)}) is ${!pathIsCompressed ? "not " : ""}compressed`);
+        const onDiskFileStream = fs.createReadStream(filePath);
+        const brotliDecompress = zlib.createBrotliDecompress();
+        let streamToListenTo: stream.Readable = pathIsCompressed ? brotliDecompress : onDiskFileStream;
+
+        const chunks: Uint8Array[] = [];
+        streamToListenTo.on(
+            "data", (chunk) => { chunks.push(Buffer.from(chunk)) }).on(
+            "error", (err) => { console.log(`Failed to read ${filePath}`)}).on(
+            `${pathIsCompressed ? "finish" : "end"}`, () => { output = Buffer.concat(chunks).toString('utf8'); });
+
+        if (pathIsCompressed) {
+            await streamPromises.pipeline(onDiskFileStream, brotliDecompress);
+        }
+        else {
+            await streamPromises.finished(onDiskFileStream);
+        }
+        return output;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Parser } from './parser.js';
 import fileParser from './fileParser.js';
+import { FileCompression } from './fileCompression.js';
 import App from './App.js';
 
 import { existsSync } from 'fs';
@@ -49,9 +50,6 @@ else {
     if (programArgs.length != 0) {
         const maxLogs = Math.min(2, programArgs.length);
         for (let i = 0; i < maxLogs; i++) {
-            if (!existsSync(programArgs[i]))
-                throw `unable to find logs at ${programArgs[i]}`;
-
             logs.push(programArgs[i]);
         }
     }
@@ -78,6 +76,8 @@ else {
     // let parser = new Parser('logs/L1120011.log');
     // let parser = new Parser('logs/L1120006.log', 'logs/L1120008.log');
     // let parser = new Parser('logs/L0526012.log', 'logs/L0526013.log');
+    
+    logs = await FileCompression.ensureFilesCompressed(logs, /*deleteOriginals=*/true);
     let parser = new Parser(...logs);
     // let parser = new Parser('logs/L0405005.log');
     // let parser = new Parser('logs/TSq9rtLa.log');

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,6 +4,7 @@ import Player from './player.js';
 import PlayerList from './playerList.js';
 import { OutputStats, PlayerClass, TeamColor, Weapon, TeamStatsComparison, OutputPlayer } from './constants.js';
 import ParserUtils, { TeamComposition } from './parserUtils.js';
+import { FileCompression } from './fileCompression.js';
 
 type RoundStats = (OutputStats | undefined)[];
 export interface ParsedStats {
@@ -53,7 +54,6 @@ export class Parser {
 
 export class RoundParser {
     private rawLogData: string = "";
-    private doneReading: boolean = false;
     private players: PlayerList = new PlayerList();
 
     private allEvents: string[] = [];
@@ -69,28 +69,8 @@ export class RoundParser {
     }
 
     public async parseFile(): Promise<void> {
-        return this.parseRound(this.filename)
-            .catch(() => console.error(`failed to parse file ${this.filename}.`));
-    }
-
-    private async parseRound(filename: string): Promise<void> {
-        return new Promise<void>((resolve, reject) => {
-            const logStream = fs.createReadStream(filename);
-            logStream.on('data', chunk => {
-                this.rawLogData += chunk;
-            }).on('end', () => {
-                this.doneReading = true;
-                this.parseData();
-                resolve();
-            }).on('error', (error) => {
-                console.error(error);
-                reject(error);
-            });
-        });
-    }
-
-    public get done(): boolean {
-        return this.doneReading;
+        this.rawLogData = await FileCompression.getDecompressedContents(this.filename);
+        return this.parseData();
     }
 
     public data(): string {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
-        "module": "ES2020",
+        "module": "ES2022",
         "moduleResolution": "node",
         "esModuleInterop": true,
-        "target": "ES2020",
+        "target": "ES2022",
         "noImplicitAny": false,
         "sourceMap": true,
         "outDir": "./dist/",


### PR DESCRIPTION
If the path passed in ends with .log, the system will now automatically create a file with ".br" appended to it that is compressed with Brotli and then delete the original file. If a path is passed in that doesn't exist but where a ".br" path exists, it will automatically pick that up.